### PR TITLE
Update BaseInputProcessor.py

### DIFF
--- a/neurokernel/LPU/InputProcessors/BaseInputProcessor.py
+++ b/neurokernel/LPU/InputProcessors/BaseInputProcessor.py
@@ -24,7 +24,7 @@ class BaseInputProcessor(object):
         # for each variable in update_input method with a ndarray of
         # length len(uids) and the correct dtype
         self.variables = {var:{'uids':uids,'input':None}
-                          for var, uids in var_list if uids}
+                          for var, uids in var_list if uids is not None}
         self.epoch = 0
         self.dest_inds = {}
         self._LPU_obj = None


### PR DESCRIPTION
Without `is not None`, an exception would be raised if `uids` is an array since `if numpy.ndarray` is ambiguous.